### PR TITLE
Disable image loading reporting through Rollbar

### DIFF
--- a/blog/wp-content/themes/wp-knowledge-base-child/functions.php
+++ b/blog/wp-content/themes/wp-knowledge-base-child/functions.php
@@ -23,15 +23,19 @@ function report_missing_image_assets() {
     //
     // Report errors on images that have already failed to load,
     // and listen for errors on images that are still loading.
-    setTimeout(function() {
-      window.jQuery("img").toArray().forEach(function(el) {
-        if (el.naturalWidth === 0 && el.naturalHeight === 0) {
-          report("Found image that failed to load: " + el.src, { src: el.src });
-        } else {
-          window.jQuery(el).on("error", reportFailedLoad);
-        }
-      });      
-    }, 10000);
+    function reportImageLoadFailures() {
+      setTimeout(function() {
+        window.jQuery("img").toArray().forEach(function(el) {
+          if (el.naturalWidth === 0 && el.naturalHeight === 0) {
+            report("Found image that failed to load: " + el.src, { src: el.src });
+          } else {
+            window.jQuery(el).on("error", reportFailedLoad);
+          }
+        });      
+      }, 10000);
+    }
+
+    // reportImageLoadFailures();
   </script>';
 }
 add_action('wp_head', 'report_missing_image_assets' );


### PR DESCRIPTION
This can be useful for debugging CDN issues, but isn't necessary in the general case and adds a bit of reporting noise.