### PR TITLE
Add change for rank key error in GetShopped plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Modified plugins are:
 - [themes/wp-knowledge-base-child/](blog/wp-content/themes/wp-knowledge-base-child)
 - [mu-plugins/IMSBasicLTI.php](blog/wp-content/mu-plugins/IMSBasicLTI.php)
 - [mu-plugins/LTI_Tool_Provider/](blog/wp-content/mu-plugins/LTI_Tool_Provider/)
+- [Get Shopped Support Forums](blog/wp-content/plugins/bbPress-Support-Forums-master) ([function](https://github.com/mit-teaching-systems-lab/wordpress-edx-forums/blob/69f2d3d830fe7dadc3f7421b1e828bb4e2d71912/blog/wp-content/plugins/bbPress-Support-Forums-master/includes/bbps-user-ranking-functions.php#L34))
 
 Some plugins and themes are used but no longer maintained upstream:
 - [GD bbPress Widgets](blog/wp-content/plugins/gd-bbpress-widgets)

--- a/blog/wp-content/plugins/bbPress-Support-Forums-master/includes/bbps-user-ranking-functions.php
+++ b/blog/wp-content/plugins/bbPress-Support-Forums-master/includes/bbps-user-ranking-functions.php
@@ -45,10 +45,10 @@ function bbps_check_ranking($user_id){
 			//if post count == the end value then this title no longer applies so remove it
 			//we subtract one here to allow for the between number eg between 1 - 4 we still
 			//want to dispaly the title if the post count is 4
-			if($post_count - 1 == $rank['end'])
+			if(array_key_exists($rank, 'end') && $post_count - 1 == $rank['end'])
 				$current_rank ="";
 			
-			if ($post_count == $rank['start'])
+			if (array_key_exists($rank, 'start') && $post_count == $rank['start'])
 				$current_rank = $rank['title'];	
 		}
 		


### PR DESCRIPTION
Addressing https://rollbar.com/MOOCs/edtech-forums/items/11/ and https://rollbar.com/MOOCs/edtech-forums/items/13/.

The GetShopped is abandoned, so just patching the direct problem for now and doing it directly in the source here.